### PR TITLE
Split out admin text from README.md into admin.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,11 @@
-# TNMD-mini-hackathon
+# TNMD Hackathon Theme 2 - Open Data - ACT Air quality monitoring data
 
-- Welcome all to the Totally Not MD Mini-Hackathon!
-- The hackathon rules can be found [here](https://github.com/TNMDCollaborationWeek).
-- The challenges have been released, you can find them [here](https://github.com/TNMDCollaborationWeek/Challenges).
-	- Note that we can be flexible with how we approach these challenges, think of them more as guidelines than specific rules.
+## Key links
 
-Join Zoom Meeting
-https://zoom.us/j/4999347056?pwd=VllLNjNaNGROZXVOZGh5R3BiL3RWZz09
+[Air Quality Monitoring Data @ data.gov.au](https://data.gov.au/dataset/ds-act-https%3A%2F%2Fwww.data.act.gov.au%2Fapi%2Fviews%2F94a5-zqnn/details?q)
 
-Meeting ID: 499 934 7056
-Passcode: bUu537
+[Information on ACT Air quality monitoring including "live" monitoring](https://www.health.act.gov.au/about-our-health-system/population-health/environmental-monitoring/monitoring-and-regulating-air)
 
-## Hackathon Theme 2 - Open Data - ACT Air quality monitoring data
-
-### Key links
-
-Air Quality Monitoring Data
-https://data.gov.au/dataset/ds-act-https%3A%2F%2Fwww.data.act.gov.au%2Fapi%2Fviews%2F94a5-zqnn/details?q
-
-Information on ACT Air quality monitoring including "live" monitoring
-https://www.health.act.gov.au/about-our-health-system/population-health/environmental-monitoring/monitoring-and-regulating-air
 
 
 

--- a/admin.md
+++ b/admin.md
@@ -1,0 +1,12 @@
+# TNMD-mini-hackathon
+
+- Welcome all to the Totally Not MD Mini-Hackathon!
+- The hackathon rules can be found [here](https://github.com/TNMDCollaborationWeek).
+- The challenges have been released, you can find them [here](https://github.com/TNMDCollaborationWeek/Challenges).
+	- Note that we can be flexible with how we approach these challenges, think of them more as guidelines than specific rules.
+
+Join Zoom Meeting
+https://zoom.us/j/4999347056?pwd=VllLNjNaNGROZXVOZGh5R3BiL3RWZz09
+
+Meeting ID: 499 934 7056
+Passcode: bUu537


### PR DESCRIPTION
As we suggested yesterday, the README should just contain project doco, so I've moved team admin to admin.md